### PR TITLE
Can revoke ownership

### DIFF
--- a/contracts/token/PXL.sol
+++ b/contracts/token/PXL.sol
@@ -104,7 +104,7 @@ contract PXL is ERC20, CustomToken, ExtendsOwnable {
      * @dev 토큰 발행 함수
      * @param _amount 발행할 토큰 수량
      */
-     function mint(uint256 _amount) onlyOwner external {
+    function mint(uint256 _amount) onlyOwner external {
         super._mint(msg.sender, _amount);
 
         emit Mint(msg.sender, _amount);

--- a/contracts/utils/ExtendsOwnable.sol
+++ b/contracts/utils/ExtendsOwnable.sol
@@ -5,6 +5,7 @@ contract ExtendsOwnable {
     mapping(address => bool) public owners;
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event OwnershipRevoked(address indexed revokedOwner);
     event OwnershipExtended(address indexed host, address indexed guest);
 
     modifier onlyOwner() {
@@ -20,6 +21,13 @@ contract ExtendsOwnable {
         require(guest != address(0));
         owners[guest] = true;
         emit OwnershipExtended(msg.sender, guest);
+    }
+
+    function removeOwner(address owner) public onlyOwner {
+        require(owner != address(0));
+        require(msg.sender != owner);
+        owners[owner] = false;
+        emit OwnershipRevoked(owner);
     }
 
     function transferOwnership(address newOwner) public onlyOwner {

--- a/contracts/utils/ExtendsOwnable.sol
+++ b/contracts/utils/ExtendsOwnable.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.24;
 
 contract ExtendsOwnable {
 
-    mapping(address => bool) owners;
+    mapping(address => bool) public owners;
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
     event OwnershipExtended(address indexed host, address indexed guest);


### PR DESCRIPTION
Owner can revoke other ownership to prevent exploit from accidentally added malicious owners.
